### PR TITLE
support changing task state afterwards - fixes #43

### DIFF
--- a/example.js
+++ b/example.js
@@ -36,8 +36,21 @@ const tasks = new Listr([
 		}
 	},
 	{
-		title: 'Install npm dependencies',
-		task: () => delay(2000)
+		title: 'Install dependencies with Yarn',
+		task: (ctx, task) => {
+			return delay(2000)
+				.then(() => {
+					ctx.yarn = false;
+
+					task.title = `${task.title} (or not)`;
+					task.skip('Yarn not available');
+				});
+		}
+	},
+	{
+		title: 'Install dependencies with npm',
+		skip: ctx => ctx.yarn !== false && 'Already installed with Yarn',
+		task: () => delay(300)
 	},
 	{
 		title: 'Run tests',

--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 const Task = require('./lib/task');
+const TaskWrapper = require('./lib/task-wrapper');
 const renderer = require('./lib/renderer');
+
+const runTask = (task, context) => new TaskWrapper(task).run(context);
 
 class Listr {
 
@@ -59,9 +62,9 @@ class Listr {
 
 		let tasks;
 		if (this._options.concurrent === true) {
-			tasks = Promise.all(this._tasks.map(task => task.run(context)));
+			tasks = Promise.all(this._tasks.map(task => runTask(task, context)));
 		} else {
-			tasks = this._tasks.reduce((promise, task) => promise.then(() => task.run(context)), Promise.resolve());
+			tasks = this._tasks.reduce((promise, task) => promise.then(() => runTask(task, context)), Promise.resolve());
 		}
 
 		return tasks

--- a/lib/task-wrapper.js
+++ b/lib/task-wrapper.js
@@ -1,0 +1,22 @@
+'use strict';
+class TaskWrapper {
+
+	constructor(task) {
+		this._task = task;
+	}
+
+	set title(title) {
+		this._task.title = title;
+
+		this._task.next({
+			type: 'TITLE',
+			data: title
+		});
+	}
+
+	run(ctx) {
+		return this._task.run(ctx, this);
+	}
+}
+
+module.exports = TaskWrapper;

--- a/lib/task-wrapper.js
+++ b/lib/task-wrapper.js
@@ -16,6 +16,10 @@ class TaskWrapper {
 		});
 	}
 
+	get title() {
+		return this._task.title;
+	}
+
 	skip(message) {
 		if (message && typeof message !== 'string') {
 			throw new TypeError(`Expected \`message\` to be of type \`string\`, got \`${typeof message}\``);

--- a/lib/task-wrapper.js
+++ b/lib/task-wrapper.js
@@ -1,4 +1,6 @@
 'use strict';
+const state = require('./state');
+
 class TaskWrapper {
 
 	constructor(task) {
@@ -12,6 +14,18 @@ class TaskWrapper {
 			type: 'TITLE',
 			data: title
 		});
+	}
+
+	skip(message) {
+		if (message && typeof message !== 'string') {
+			throw new TypeError(`Expected \`message\` to be of type \`string\`, got \`${typeof message}\``);
+		}
+
+		if (message) {
+			this._task._output = message;
+		}
+
+		this._task.state = state.SKIPPED;
 	}
 
 	run(ctx) {

--- a/lib/task.js
+++ b/lib/task.js
@@ -80,7 +80,7 @@ class Task extends Subject {
 		return this._state === state.FAILED;
 	}
 
-	run(context) {
+	run(context, wrapper) {
 		const handleResult = result => {
 			// Detect the subtask
 			if (utils.isListr(result)) {
@@ -139,7 +139,7 @@ class Task extends Subject {
 					return;
 				}
 
-				return handleResult(this.task(context));
+				return handleResult(this.task(context, wrapper));
 			})
 			.then(() => {
 				if (this.isPending()) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "is-stream": "^1.1.0",
     "listr-silent-renderer": "^1.1.1",
     "listr-update-renderer": "^0.1.1",
-    "listr-verbose-renderer": "^0.2.1",
+    "listr-verbose-renderer": "^0.3.0",
     "log-symbols": "^1.0.2",
     "log-update": "^1.0.2",
     "ora": "^0.2.3",

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,8 @@ const tasks = new Listr([
 ]);
 ```
 
+> Tip: You can still skip a task while already executing the `task` function with the [task object](#task-object).
+
 
 ## Context
 
@@ -274,6 +276,7 @@ Every task is an observable. The task emits three different events and every eve
 1. The state of the task has changed (`STATE`).
 2. The task outputted data (`DATA`).
 3. The task returns a subtask list (`SUBTASKS`).
+4. The task's title changed (`TITLE`).
 
 This allows you to flexibly build up your UI. Let's render every task that starts executing.
 

--- a/readme.md
+++ b/readme.md
@@ -44,8 +44,13 @@ const tasks = new Listr([
 		}
 	},
 	{
-		title: 'Install package dependencies',
-		task: () => execa('npm', ['install'])
+		title: 'Install package dependencies with Yarn',
+		task: (ctx, task) => execa('yarn')
+			.catch(() => {
+				task.title = 'Install package dependencies with npm (Yarn not available)';
+
+				return execa('npm', ['install']);
+			})
 	},
 	{
 		title: 'Run tests',
@@ -207,6 +212,33 @@ tasks.run({
 	console.log(ctx);
 	//=> {foo: 'bar', unicorn: 'rainbow'}
 });
+```
+
+
+## Task object
+
+A special task object is being passed as second argument into the `task` function. This task object lets you change the title while running your task or you can skip it depending on some results.
+
+```js
+const tasks = new Listr([
+	{
+		title: 'Install package dependencies with Yarn',
+		task: (ctx, task) => execa('yarn')
+			.catch(() => {
+				ctx.yarn = false;
+
+				task.title = `${task.title} (or not)`;
+				task.skip('Yarn not available');
+			})
+	},
+	{
+		title: 'Install package dependencies with npm',
+		skip: ctx => ctx.yarn !== false && 'Dependencies already installed with Yarn'
+		task: () => execa('npm', ['install'])
+	}
+]);
+
+tasks.run();
 ```
 
 

--- a/test/fixtures/simple-renderer.js
+++ b/test/fixtures/simple-renderer.js
@@ -10,6 +10,8 @@ const renderHelper = (task, event) => {
 		}
 	} else if (event.type === 'DATA') {
 		console.log(`> ${event.data}`);
+	} else if (event.type === 'TITLE') {
+		console.log(`${task.title} [title changed]`);
 	}
 };
 

--- a/test/task-wrapper.js
+++ b/test/task-wrapper.js
@@ -1,0 +1,63 @@
+import {serial as test} from 'ava';
+import Listr from '../';
+import SimpleRenderer from './fixtures/simple-renderer';
+import {testOutput} from './fixtures/utils';
+
+test('changing the title during task execution', async t => {
+	const list = new Listr([
+		{
+			title: 'foo',
+			task: (ctx, task) => {
+				task.title = 'foo bar';
+			}
+		}
+	], {renderer: SimpleRenderer});
+
+	testOutput(t, [
+		'foo [started]',
+		'foo bar [title changed]',
+		'foo bar [completed]',
+		'done'
+	]);
+
+	await list.run();
+});
+
+test('skip task during task execution with no message', async t => {
+	const list = new Listr([
+		{
+			title: 'foo',
+			task: (ctx, task) => {
+				task.skip();
+			}
+		}
+	], {renderer: SimpleRenderer});
+
+	testOutput(t, [
+		'foo [started]',
+		'foo [skipped]',
+		'done'
+	]);
+
+	await list.run();
+});
+
+test('skip task during task execution with message', async t => {
+	const list = new Listr([
+		{
+			title: 'foo',
+			task: (ctx, task) => {
+				task.skip('foo bar');
+			}
+		}
+	], {renderer: SimpleRenderer});
+
+	testOutput(t, [
+		'foo [started]',
+		'foo [skipped]',
+		'> foo bar',
+		'done'
+	]);
+
+	await list.run();
+});

--- a/test/task-wrapper.js
+++ b/test/task-wrapper.js
@@ -61,3 +61,30 @@ test('skip task during task execution with message', async t => {
 
 	await list.run();
 });
+
+test('skip subtask', async t => {
+	const list = new Listr([
+		{
+			title: 'foo',
+			task: () => new Listr([
+				{
+					title: 'bar',
+					task: (ctx, task) => {
+						task.skip('foo bar');
+					}
+				}
+			], {renderer: SimpleRenderer})
+		}
+	], {renderer: SimpleRenderer});
+
+	testOutput(t, [
+		'foo [started]',
+		'bar [started]',
+		'bar [skipped]',
+		'> foo bar',
+		'foo [completed]',
+		'done'
+	]);
+
+	await list.run();
+});


### PR DESCRIPTION
This PR fixes #43.

- [x] Add support for a title change in the `verbose` renderer (https://github.com/SamVerschueren/listr-verbose-renderer/commit/413c810f1a89b30f322d635461b629591fdab3aa)
- [x] Add possibility to skip a task
- [x] Add documentation
- [x] Write tests