### PR TITLE
throw error when exitOnError set to false and errors occur - fixes #48

### DIFF
--- a/lib/listr-error.js
+++ b/lib/listr-error.js
@@ -1,0 +1,9 @@
+'use strict';
+class ListrError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = 'ListrError';
+	}
+}
+
+module.exports = ListrError;

--- a/lib/task-wrapper.js
+++ b/lib/task-wrapper.js
@@ -1,10 +1,12 @@
 'use strict';
 const state = require('./state');
+const ListrError = require('./listr-error');
 
 class TaskWrapper {
 
-	constructor(task) {
+	constructor(task, errors) {
 		this._task = task;
+		this._errors = errors;
 	}
 
 	set title(title) {
@@ -18,6 +20,16 @@ class TaskWrapper {
 
 	get title() {
 		return this._task.title;
+	}
+
+	report(error) {
+		if (error instanceof ListrError) {
+			for (const err of error.errors) {
+				this._errors.push(err);
+			}
+		} else {
+			this._errors.push(error);
+		}
 	}
 
 	skip(message) {

--- a/lib/task.js
+++ b/lib/task.js
@@ -6,6 +6,7 @@ const Subject = require('rxjs/Subject').Subject;
 const renderer = require('./renderer');
 const state = require('./state');
 const utils = require('./utils');
+const ListrError = require('./listr-error');
 
 const defaultSkipFn = () => false;
 
@@ -179,12 +180,19 @@ class Task extends Subject {
 			.catch(err => {
 				this.state = state.FAILED;
 
+				if (err instanceof ListrError) {
+					wrapper.report(err);
+					return;
+				}
+
 				this._output = err.message;
 
 				this.next({
 					type: 'DATA',
 					data: err.message
 				});
+
+				wrapper.report(err);
 
 				if (this._listr.exitOnError !== false) {
 					// Do not exit when explicitely set to `false`


### PR DESCRIPTION
This PR should solve #48.

There's still one thing I'm not sure about. What if we have this task list

```js
	const list = new Listr([
		{
			title: 'foo',
			task: () => Promise.reject(new Error('Foo failed'))
		},
		{
			title: 'bar',
			task: () => {
				return new Listr([
					{
						title: 'unicorn',
						task: () => Promise.reject(new Error('Unicorn failed'))
					}
				]);
			}
		},
		{
			title: 'baz',
			task: () => Promise.resolve()
		}
	], {
		exitOnError: false,
		renderer: SimpleRenderer
	});
```

What should this output? Should it mark `bar` as failed (because the inner task failed) or should it be marked as completed?

```
foo [started]
foo [failed]
> Foo failed
bar [started]
unicorn [started]
unicorn [failed]
> Unicorn failed
bar [completed]
baz [started]
baz [completed]
done
```


```
foo [started]
foo [failed]
> Foo failed
bar [started]
unicorn [started]
unicorn [failed]
> Unicorn failed
bar [failed]
> Unicorn failed
baz [started]
baz [completed]
done
```

// @okonet