### PR TITLE
chore: Add lint-staged as a pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "scripts": {
     "test": "clinton && xo && nyc ava",
-    "coveralls": "nyc report --reporter=text-lcov | coveralls"
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
+    "lint:staged": "lint-staged"
   },
   "files": [
     "index.js",
@@ -60,11 +61,17 @@
     "coveralls": "^2.11.14",
     "delay": "^1.3.1",
     "hook-std": "^0.2.0",
+    "lint-staged": "^3.3.1",
     "nyc": "^8.3.2",
+    "pre-commit": "^1.2.2",
     "xo": "*",
     "zen-observable": "^0.3.0"
   },
   "xo": {
     "esnext": true
-  }
+  },
+  "lint-staged": {
+    "*.js": "xo"
+  },
+  "pre-commit": "lint:staged"
 }


### PR DESCRIPTION
This PR adds lint-staged that will run `xo` for staged `*.js` files as a pre-commit hook.