### PR TITLE
Docs: update screenshot path for npm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 > Terminal task list
 
-<img src="media/screenshot.gif">
+<img src="https://raw.githubusercontent.com/SamVerschueren/listr/master/media/screenshot.gif">
 
 ## Install
 


### PR DESCRIPTION
**Fix:**

- update screenshot path from `media/screenshot.gif` to `https://raw.githubusercontent.com/SamVerschueren/listr/master/media/screenshot.gif`

The gif is not visible on the npm website. I added the absolut path to the `img` tag, so the gif is also displayed on the npm website, not only on github.