### PR TITLE
Recognise `RxObservable.of` and others

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict';
+const RxObservable = require('rxjs').Observable;
 
 exports.isListr = obj => Boolean(obj && obj.setRenderer && obj.add && obj.run);
 // https://github.com/sindresorhus/is-observable/issues/1
-exports.isObservable = obj => Boolean(obj && typeof obj.subscribe === 'function' && obj.constructor.name === 'Observable');
+exports.isObservable = obj => Boolean(obj && typeof obj.subscribe === 'function' && ((obj.constructor.name === 'Observable') || obj instanceof RxObservable));

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,5 +17,6 @@ test('isObservable', t => {
 	t.false(isObservable(new Listr([])));
 	t.false(isObservable(new Promise(() => {})));
 	t.true(isObservable(new RxObservable(() => {})));
+	t.true(isObservable(RxObservable.of('test')));
 	t.true(isObservable(new ZenObservable(() => {})));
 });


### PR DESCRIPTION
Hi, Sam
I found that although *Listr* claims that it supports RxObservable but in fact, it only recognises the plainest RxObervable comes from `new Observable()`. Neither `RxObservable.of()` nor `RxObservable.combineLatest()` and more will be recognised. 

I add the instance check base on this SO answer. https://stackoverflow.com/a/41452513/1016407

Please let me know if there is any problem and please kindly accept the PR.