### PR TITLE
Bind task object itself before calling task()

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -43,7 +43,7 @@ class Task extends Subject {
 		this.output = undefined;
 		this.title = task.title;
 		this.skip = task.skip || defaultSkipFn;
-		this.task = task.task;
+		this.task = task.task.bind(task);
 	}
 
 	get subtasks() {


### PR DESCRIPTION
Binds the 'task' object itself to task() function so that the 'task' object can use inner variables, etc.

e.g.

```
class SampleTask {
    private n: number
    constructor(n: number) { this.n = n }
    title = "SampleTask"
    task(ctx: any, task: any) { task.skip(`${this.n}`) }
}
```

Without the bind, the variable n is references else where.