### PR TITLE
fix(deps): Add support for RxJS 6

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
 const Observable = require('rxjs/Observable').Observable;
 const logSymbols = require('log-symbols');
 const delay = require('delay');
-const Listr = require('./');
+const Listr = require('.');
 
 const renderer = process.argv[2];
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ const runTask = (task, context, errors) => {
 };
 
 class Listr {
-
 	constructor(tasks, opts) {
 		if (tasks && !Array.isArray(tasks) && typeof tasks === 'object') {
 			if (typeof tasks.title === 'string' && typeof tasks.task === 'function') {

--- a/lib/task-wrapper.js
+++ b/lib/task-wrapper.js
@@ -3,7 +3,6 @@ const state = require('./state');
 const ListrError = require('./listr-error');
 
 class TaskWrapper {
-
 	constructor(task, errors) {
 		this._task = task;
 		this._errors = errors;

--- a/lib/task.js
+++ b/lib/task.js
@@ -1,7 +1,7 @@
 'use strict';
 const isPromise = require('is-promise');
 const streamToObservable = require('stream-to-observable');
-const Subject = require('rxjs/Subject').Subject;
+const Subject = require('rxjs').Subject;
 const renderer = require('./renderer');
 const state = require('./state');
 const utils = require('./utils');
@@ -10,7 +10,6 @@ const ListrError = require('./listr-error');
 const defaultSkipFn = () => false;
 
 class Task extends Subject {
-
 	constructor(listr, task, options) {
 		super();
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "log-update": "^1.0.2",
     "ora": "^0.2.3",
     "p-map": "^1.1.1",
-    "rxjs": "^5.6.0-forward-compat.0 || ^6.0.0-rc.0",
+    "rxjs": "^5.6.0-forward-compat.0 || ^6.0.0-rc.1",
     "stream-to-observable": "^0.2.0",
     "strip-ansi": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "log-update": "^1.0.2",
     "ora": "^0.2.3",
     "p-map": "^1.1.1",
-    "rxjs": "^5.4.2",
+    "rxjs": "^5.6.0-forward-compat.0 || ^6.0.0-rc.0",
     "stream-to-observable": "^0.2.0",
     "strip-ansi": "^3.0.1"
   },

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -1,6 +1,6 @@
 import {serial as test} from 'ava';
 import delay from 'delay';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/enabled.js
+++ b/test/enabled.js
@@ -1,5 +1,5 @@
 import {serial as test} from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/exit-on-error.js
+++ b/test/exit-on-error.js
@@ -1,5 +1,5 @@
 import {serial as test} from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/output.js
+++ b/test/output.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {Observable} from 'rxjs/Observable';
+import {Observable} from 'rxjs';
 import Listr from '../';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';

--- a/test/output.js
+++ b/test/output.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import {Observable} from 'rxjs';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import test from 'ava';
 import split from 'split';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/subtask.js
+++ b/test/subtask.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/task-wrapper.js
+++ b/test/task-wrapper.js
@@ -1,5 +1,5 @@
 import {serial as test} from 'ava';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import Listr from '../';
+import Listr from '..';
 
 test('create', t => {
 	t.notThrows(() => new Listr());

--- a/test/tty.js
+++ b/test/tty.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {Observable} from 'rxjs/Observable';
+import {Observable} from 'rxjs';
 import Listr from '../';
 import SimpleRenderer from './fixtures/simple-renderer';
 import TTYRenderer from './fixtures/tty-renderer';

--- a/test/tty.js
+++ b/test/tty.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import {Observable} from 'rxjs';
-import Listr from '../';
+import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import TTYRenderer from './fixtures/tty-renderer';
 import {testOutput} from './fixtures/utils';

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {Observable as RxObservable} from 'rxjs';
 import ZenObservable from 'zen-observable';
-import Listr from '../';
+import Listr from '..';
 import {isListr, isObservable} from '../lib/utils';
 
 test('isListr', t => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import {Observable as RxObservable} from 'rxjs/Observable';
+import {Observable as RxObservable} from 'rxjs';
 import ZenObservable from 'zen-observable';
 import Listr from '../';
 import {isListr, isObservable} from '../lib/utils';


### PR DESCRIPTION
Also cleans up linter errors with latest version of `xo`

BREAKING CHANGE:

Minimum dependency on RxJS is ^5.6.0-forward-compat.0 || ^6.0.0-rc.1