### PR TITLE
Drop support for Node.js <= 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ node_js:
   - '10'
   - '8'
   - '6'
-  - '4'
 after_script:
   - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ environment:
     - nodejs_version: '10'
     - nodejs_version: '8'
     - nodejs_version: '6'
-    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - set CI=true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "github.com/SamVerschueren"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "clinton && xo && nyc ava",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nyc": "^8.3.2",
     "pre-commit": "^1.2.2",
     "split": "^1.0.1",
-    "xo": "^0.20.3",
+    "xo": "*",
     "zen-observable": "^0.3.0"
   },
   "lint-staged": {


### PR DESCRIPTION
- Update engines field in package.json.
- Update Travis and Appveyor CI config, do not test node 4.

Let me know if there are any other changes you'd like me to do.

Closes #98 