### PR TITLE
added suspending update renderer for task

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -43,11 +43,20 @@ class Task extends Subject {
 		this.title = task.title;
 		this.skip = task.skip || defaultSkipFn;
 		this.task = task.task;
+		this.taskOptions = task.options;
 	}
 
 	get subtasks() {
 		return this._subtasks;
 	}
+
+	shouldSuspendUpdateRenderer() {
+		try{
+			return this.taskOptions.suspendUpdateRenderer;
+		}catch(TypeError){
+			return false;
+		}
+    	}
 
 	set state(state) {
 		this._state = state;


### PR DESCRIPTION
In order to fix issue [np issue 79](https://github.com/sindresorhus/np/issues/79), these changes add an optional suspend-flag for every task.
The suspend-flag is later used, to suspend the listr-update-renderer.
