### PR TITLE
Repair unit-tests to be compatible with ava 2.4.0

### DIFF
--- a/lib/task.js
+++ b/lib/task.js
@@ -160,6 +160,7 @@ class Task extends Subject {
 					if (typeof skipped === 'string') {
 						this.output = skipped;
 					}
+
 					this.state = state.SKIPPED;
 					return;
 				}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,28 @@
 	"pre-commit": "lint:staged",
 	"xo": {
 		"rules": {
-			"prefer-destructuring": "off"
+			"prefer-destructuring": "off",
+			"ava/no-import-test-files": [
+				"off",
+				{
+					"files": [
+						"test/*"
+					]
+				}
+			],
+			"accessor-pairs": [
+				"off",
+				{
+					"files": [
+						"lib/task-wrapper.js"
+					]
+				}
+			]
 		}
+	},
+	"ava": {
+		"files": [
+			"!test/fixtures"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "listr",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "Terminal task list",
 	"license": "MIT",
 	"repository": "SamVerschueren/listr",

--- a/test/concurrent.js
+++ b/test/concurrent.js
@@ -1,8 +1,8 @@
 import {serial as test} from 'ava';
 import delay from 'delay';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 const tasks = [
 	{

--- a/test/enabled.js
+++ b/test/enabled.js
@@ -1,7 +1,7 @@
 import {serial as test} from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('do not run disabled tasks', async t => {
 	const list = new Listr([

--- a/test/exit-on-error.js
+++ b/test/exit-on-error.js
@@ -1,7 +1,7 @@
 import {serial as test} from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 const tasks = [
 	{
@@ -15,8 +15,6 @@ const tasks = [
 ];
 
 test('exit on error', async t => {
-	t.plan(5);
-
 	const list = new Listr(tasks, {
 		renderer: SimpleRenderer
 	});
@@ -26,7 +24,7 @@ test('exit on error', async t => {
 		'foo [failed]',
 		'> Something went wrong',
 		'done'
-	]);
+	], 5);
 
 	try {
 		await list.run();
@@ -36,8 +34,6 @@ test('exit on error', async t => {
 });
 
 test('set `exitOnError` to false', async t => {
-	t.plan(8);
-
 	const list = new Listr(tasks, {
 		exitOnError: false,
 		renderer: SimpleRenderer
@@ -50,7 +46,7 @@ test('set `exitOnError` to false', async t => {
 		'bar [started]',
 		'bar [completed]',
 		'done'
-	]);
+	], 8);
 
 	try {
 		await list.run();
@@ -61,8 +57,6 @@ test('set `exitOnError` to false', async t => {
 });
 
 test('set `exitOnError` to false in nested list', async t => {
-	t.plan(15);
-
 	const list = new Listr([
 		{
 			title: 'foo',
@@ -106,7 +100,7 @@ test('set `exitOnError` to false in nested list', async t => {
 		'baz [started]',
 		'baz [completed]',
 		'done'
-	]);
+	], 15);
 
 	try {
 		await list.run();
@@ -118,8 +112,6 @@ test('set `exitOnError` to false in nested list', async t => {
 });
 
 test('set `exitOnError` to false in root', async t => {
-	t.plan(17);
-
 	const list = new Listr([
 		{
 			title: 'foo',
@@ -163,7 +155,7 @@ test('set `exitOnError` to false in root', async t => {
 		'baz [started]',
 		'baz [completed]',
 		'done'
-	]);
+	], 17);
 
 	try {
 		await list.run();
@@ -176,8 +168,6 @@ test('set `exitOnError` to false in root', async t => {
 });
 
 test('set `exitOnError` to false in root and true in child', async t => {
-	t.plan(16);
-
 	const list = new Listr([
 		{
 			title: 'foo',
@@ -222,7 +212,7 @@ test('set `exitOnError` to false in root and true in child', async t => {
 		'baz [started]',
 		'baz [completed]',
 		'done'
-	]);
+	], 16);
 
 	try {
 		await list.run();
@@ -235,8 +225,6 @@ test('set `exitOnError` to false in root and true in child', async t => {
 });
 
 test('exit on error throws error object with context', async t => {
-	t.plan(10);
-
 	const list = new Listr([
 		{
 			title: 'foo',
@@ -260,7 +248,7 @@ test('exit on error throws error object with context', async t => {
 		'bar [started]',
 		'bar [completed]',
 		'done'
-	]);
+	], 10);
 
 	try {
 		await list.run();

--- a/test/fixtures/utils.js
+++ b/test/fixtures/utils.js
@@ -1,8 +1,9 @@
 'use strict';
 const hookStd = require('hook-std');
 
-exports.testOutput = (t, expected) => {
-	t.plan(t._test.planCount || expected.length);
+exports.testOutput = (t, expected, plannedAssertions) => {
+	t.plan(plannedAssertions || expected.length);
+
 	let i = 0;
 
 	return hookStd.stdout((actual, unhook) => {

--- a/test/output.js
+++ b/test/output.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import {Observable} from 'rxjs';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('output', async t => {
 	const list = new Listr([

--- a/test/renderer.js
+++ b/test/renderer.js
@@ -1,7 +1,7 @@
 import test from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('renderer class', async t => {
 	const list = new Listr([

--- a/test/skip.js
+++ b/test/skip.js
@@ -1,7 +1,7 @@
 import test from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('continue execution if skip() returns false or Promise for false', async t => {
 	t.plan(5); // Verify the correct number of tasks were executed

--- a/test/stream.js
+++ b/test/stream.js
@@ -2,9 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import test from 'ava';
 import split from 'split';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('output', async t => {
 	const list = new Listr([

--- a/test/subtask.js
+++ b/test/subtask.js
@@ -1,7 +1,7 @@
 import test from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('renderer class', async t => {
 	const list = new Listr([

--- a/test/task-wrapper.js
+++ b/test/task-wrapper.js
@@ -1,7 +1,7 @@
 import {serial as test} from 'ava';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 test('changing the title during task execution', async t => {
 	const list = new Listr([

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,7 @@ test('throw error if task rejects', async t => {
 		}
 	], {renderer: 'silent'});
 
-	await t.throws(list.run(), 'foo bar');
+	await t.throwsAsync(list.run(), 'foo bar');
 });
 
 test('throw error if task throws', async t => {
@@ -68,7 +68,7 @@ test('throw error if task throws', async t => {
 		}
 	], {renderer: 'silent'});
 
-	await t.throws(list.run(), 'foo bar');
+	await t.throwsAsync(list.run(), 'foo bar');
 });
 
 test('throw error if task skip rejects', async t => {
@@ -80,7 +80,7 @@ test('throw error if task skip rejects', async t => {
 		}
 	], {renderer: 'silent'}, {renderer: 'silent'});
 
-	await t.throws(list.run(), 'skip foo');
+	await t.throwsAsync(list.run(), 'skip foo');
 });
 
 test('throw error if task skip throws', async t => {
@@ -94,7 +94,7 @@ test('throw error if task skip throws', async t => {
 		}
 	], {renderer: 'silent'});
 
-	await t.throws(list.run(), 'skip foo');
+	await t.throwsAsync(list.run(), 'skip foo');
 });
 
 test('execute tasks', async t => {
@@ -105,7 +105,7 @@ test('execute tasks', async t => {
 		}
 	], {renderer: 'silent'});
 
-	await t.notThrows(list.run());
+	await t.notThrowsAsync(list.run());
 });
 
 test('add tasks', t => {

--- a/test/tty.js
+++ b/test/tty.js
@@ -1,9 +1,9 @@
 import test from 'ava';
 import {Observable} from 'rxjs';
-import Listr from '..';
 import SimpleRenderer from './fixtures/simple-renderer';
 import TTYRenderer from './fixtures/tty-renderer';
 import {testOutput} from './fixtures/utils';
+import Listr from '..';
 
 const ttyOutput = [
 	'foo [started]',

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,8 +1,8 @@
 import test from 'ava';
 import {Observable as RxObservable} from 'rxjs';
 import ZenObservable from 'zen-observable';
-import Listr from '..';
 import {isListr, isObservable} from '../lib/utils';
+import Listr from '..';
 
 test('isListr', t => {
 	t.false(isListr(null));


### PR DESCRIPTION
The unit-tests are repaired in this pull-request. So they are compatible with last release of
ava:
According to [1696](https://github.com/avajs/ava/pull/1696), the private variable `t._test` was removed in Feb. 2018.
The rejected promises now are verified with `throwsAsync`. So these test don't fail anymore.
@SamVerschueren:
I hope you can review these changes asap.