### PR TITLE
Update listr-verbose-renderer@0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"is-stream": "^1.1.0",
 		"listr-silent-renderer": "^1.1.1",
 		"listr-update-renderer": "^0.5.0",
-		"listr-verbose-renderer": "^0.5.0",
+		"listr-verbose-renderer": "^0.6.0",
 		"p-map": "^2.0.0",
 		"rxjs": "^6.3.3"
 	},


### PR DESCRIPTION
This avoids a transient dependency on the old 1.x version of date-fns.