### PR TITLE
Bump @samverschueren/stream-to-observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"idle"
 	],
 	"dependencies": {
-		"@samverschueren/stream-to-observable": "^0.3.0",
+		"@samverschueren/stream-to-observable": "^0.3.1",
 		"is-observable": "^2.0.0",
 		"is-promise": "^2.1.0",
 		"is-stream": "^1.1.0",


### PR DESCRIPTION
This is a very minor but very important change, as it breaks Cypress@6, see the issue: https://github.com/cypress-io/cypress/issues/6600

Fixed in https://github.com/SamVerschueren/stream-to-observable/commit/1e16aace95e889c3967cf63fe43baf74b5915ffa